### PR TITLE
feat: Add init result instructions to client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -83,6 +83,8 @@ class Client
 
     protected string $preferredProtocolVersion = '2024-11-05';
 
+    protected string $instructions = null;
+
     /**
      * @internal Use ClientBuilder::make()->...->build() instead.
      */
@@ -126,6 +128,11 @@ class Client
     public function getNegotiatedCapabilities(): ?Capabilities
     {
         return $this->serverCapabilities;
+    }
+
+    public function getInstructions(): ?string
+    {
+        return $this->instructions;
     }
 
     public function getNegotiatedProtocolVersion(): ?string
@@ -920,6 +927,7 @@ class Client
                 $this->serverName = $initResult->serverName;
                 $this->serverVersion = $initResult->serverVersion;
                 $this->serverCapabilities = $initResult->capabilities;
+                $this->instructions = $initResult->instructions;
 
                 $this->logger->debug("Sending 'initialized' notification to '{$this->getServerName()}'.");
 

--- a/tests/Feature/ClientAsyncApiTest.php
+++ b/tests/Feature/ClientAsyncApiTest.php
@@ -145,7 +145,7 @@ it('can initialize connection asynchronously', function () {
         'protocolVersion' => '2024-11-05',
         'serverInfo' => ['name' => 'AsyncMockServer', 'version' => '2.0'],
         'capabilities' => ['tools' => new \stdClass],
-        'instructions' => 'You are a helpful assistant',
+        'instructions' => 'test instructions',
     ];
     $initResponse = new Response(id: $initRequestId, result: $initResultData);
 
@@ -161,7 +161,7 @@ it('can initialize connection asynchronously', function () {
     expect($this->client->getStatus())->toBe(ConnectionStatus::Ready);
     expect($this->client->getServerName())->toBe('AsyncMockServer');
     expect($this->client->getServerVersion())->toBe('2.0');
-    expect($this->client->getInstructions())->toBe('You are a helpful assistant');
+    expect($this->client->getInstructions())->toBe('test instructions');
 
 })->group('usesLoop');
 

--- a/tests/Feature/ClientAsyncApiTest.php
+++ b/tests/Feature/ClientAsyncApiTest.php
@@ -145,6 +145,7 @@ it('can initialize connection asynchronously', function () {
         'protocolVersion' => '2024-11-05',
         'serverInfo' => ['name' => 'AsyncMockServer', 'version' => '2.0'],
         'capabilities' => ['tools' => new \stdClass],
+        'instructions' => 'You are a helpful assistant',
     ];
     $initResponse = new Response(id: $initRequestId, result: $initResultData);
 
@@ -160,6 +161,7 @@ it('can initialize connection asynchronously', function () {
     expect($this->client->getStatus())->toBe(ConnectionStatus::Ready);
     expect($this->client->getServerName())->toBe('AsyncMockServer');
     expect($this->client->getServerVersion())->toBe('2.0');
+    expect($this->client->getInstructions())->toBe('You are a helpful assistant');
 
 })->group('usesLoop');
 

--- a/tests/Feature/ClientSyncApiTest.php
+++ b/tests/Feature/ClientSyncApiTest.php
@@ -71,7 +71,7 @@ it('initializes successfully', function () {
         $this->messageListenerCallback,
         $this->mockTransport,
         $this->loop,
-        'You are a helpful assistant',
+        'test instructions',
     );
 
     // Act
@@ -81,7 +81,7 @@ it('initializes successfully', function () {
     expect($returnedClient)->toBe($this->client);
     expect($this->client->getStatus())->toBe(ConnectionStatus::Ready);
     expect($this->client->getServerName())->toBe('MockServer');
-    expect($this->client->getInstructions())->toBe('You are a helpful assistant');
+    expect($this->client->getInstructions())->toBe('test instructions');
 
 })->group('usesLoop');
 

--- a/tests/Feature/ClientSyncApiTest.php
+++ b/tests/Feature/ClientSyncApiTest.php
@@ -70,7 +70,8 @@ it('initializes successfully', function () {
         $initRequestId,
         $this->messageListenerCallback,
         $this->mockTransport,
-        $this->loop
+        $this->loop,
+        'You are a helpful assistant',
     );
 
     // Act
@@ -80,6 +81,7 @@ it('initializes successfully', function () {
     expect($returnedClient)->toBe($this->client);
     expect($this->client->getStatus())->toBe(ConnectionStatus::Ready);
     expect($this->client->getServerName())->toBe('MockServer');
+    expect($this->client->getInstructions())->toBe('You are a helpful assistant');
 
 })->group('usesLoop');
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -71,7 +71,8 @@ function simulateSuccessfulHandshake(
     &$messageListenerCallback,
     MockInterface&TransportInterface $mockTransport,
     LoopInterface $loop,
-    ?array $serverCaps = null
+    ?array $serverCaps = null,
+    ?string $instructions = null,
 ): void {
     $connectDeferred = new Deferred;
     $mockTransport->shouldReceive('connect')->once()->andReturn($connectDeferred->promise());
@@ -91,6 +92,7 @@ function simulateSuccessfulHandshake(
         'protocolVersion' => '2024-11-05',
         'serverInfo' => ['name' => 'MockServer', 'version' => '1.0'],
         'capabilities' => $serverCaps ?? ['tools' => new stdClass],
+        'instructions' => $instructions,
     ];
     $initResponse = new Response($initRequestId, $initResultData);
     $loop->addTimer(0.003, fn () => $initResponseDeferred->resolve(null));


### PR DESCRIPTION
Hi there, I noticed that the instructions property that already exists on the [InitializeResult](https://github.com/php-mcp/client/blob/main/src/JsonRpc/Results/InitializeResult.php#L24) class is not set on the Client. 

This is useful to be able to set the system message within a prompt.

> This can be used by clients to improve the LLM’s understanding of available tools, resources, etc. It can be thought of like a “hint” to the model. For example, this information MAY be added to the system prompt.

Equivalent PR for the TS client - https://github.com/modelcontextprotocol/typescript-sdk/pull/133

References 
- https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2024-11-05/schema.ts#L170-L175
- https://modelcontextprotocol.io/specification/2025-06-18/schema#initializeresult
